### PR TITLE
Added a BlockSniper addon

### DIFF
--- a/BlockSniperAddon.php
+++ b/BlockSniperAddon.php
@@ -22,11 +22,15 @@ namespace BlockHorizons\ScoreHud\Addons {
 		 */
 		public function getProcessedTags(Player $player): array{
 			$brush = SessionManager::getPlayerSession($player)->getBrush();
+			$size = (string) $brush->size;
+			if($brush->getShape()->usesThreeLengths()){
+				$size = (string) $brush->width . "x" . (string) $brush->length . "x" . (string) $brush->height;
+			}
 			return [
 				"{brush_shape}" => $brush->getShape()->getName(),
 				"{brush_type}" => $brush->getType()->getName(),
 				"{brush_mode}" => $brush->mode === Brush::MODE_BRUSH ? "Brush" : "Selection",
-				"{brush_size}" => $brush->size,
+				"{brush_size}" => $size,
 			];
 		}
 	}

--- a/BlockSniperAddon.php
+++ b/BlockSniperAddon.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @name BlockSniperAddon
+ * @main BlockHorizons\ScoreHud\Addons\BlockSniperAddon
+ * @depend BlockSniper
+ */
+namespace BlockHorizons\ScoreHud\Addons {
+
+	use BlockHorizons\BlockSniper\brush\Brush;
+	use BlockHorizons\BlockSniper\sessions\SessionManager;
+	use JackMD\ScoreHud\addon\AddonBase;
+	use pocketmine\Player;
+
+	class BlockSniperAddon extends AddonBase{
+
+		/**
+		 * @param Player $player
+		 * @return array
+		 */
+		public function getProcessedTags(Player $player): array{
+			$brush = SessionManager::getPlayerSession($player)->getBrush();
+			return [
+				"{brush_shape}" => $brush->getShape()->getName(),
+				"{brush_type}" => $brush->getType()->getName(),
+				"{brush_mode}" => $brush->mode === Brush::MODE_BRUSH ? "Brush" : "Selection",
+				"{brush_size}" => $brush->size,
+			];
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds an addon for BlockSniper, implementing 4 tags.

`brush_shape`: displays the current active brush shape.
`brush_type`: displays the current active brush type.
`brush_size`: displays the size of the brush, either a single integer if it is a radius or the dimensions in a format of `widthxlengthxheight`
`brush_mode`: displays either `Brush` or `Selection`, depending on the brush mode active.